### PR TITLE
Automatically publish Docker images from Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 *
 !app/
 !pyproject.toml
+!.pre-commit-config.yaml
+!.flake8

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!app/
+!pyproject.toml

--- a/.github/workflows/pub_img.yml
+++ b/.github/workflows/pub_img.yml
@@ -37,5 +37,5 @@ jobs:
         with:
           file: ./Dockerfile
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: mverleg/age_of_gold:latest,mverleg/age_of_gold:${{ steps.date.outputs.date }},mverleg/age_of_gold:${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/pub_img.yml
+++ b/.github/workflows/pub_img.yml
@@ -38,4 +38,4 @@ jobs:
           file: ./Dockerfile
           context: .
           push: true
-          tags: mverleg/rust_nightly_musl_base:nodeps,mverleg/rust_nightly_musl_base:nodeps_${{ steps.date.outputs.date }},mverleg/rust_nightly_musl_base:nodeps_${{ steps.date.outputs.date }}_${{ github.run_number }}
+          tags: mverleg/age_of_gold:latest,mverleg/age_of_gold:${{ steps.date.outputs.date }},mverleg/age_of_gold:${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/pub_img.yml
+++ b/.github/workflows/pub_img.yml
@@ -1,0 +1,41 @@
+
+# GENERATED: This file is automatically updated by 'Bump dependencies', local changes will be overwritten!
+
+# Note: it is not safe to run this workflow multiple times concurrently.
+
+name: 'Docker image'
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_image:
+    name: Build base image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: mverleg
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          context: .
+          push: true
+          tags: mverleg/rust_nightly_musl_base:nodeps,mverleg/rust_nightly_musl_base:nodeps_${{ steps.date.outputs.date }},mverleg/rust_nightly_musl_base:nodeps_${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ COPY pyproject.toml /app/pyproject.toml
 
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir poetry && \
+    pip3 install --no-cache-dir pre-commit && \
     poetry config virtualenvs.create false && \
     poetry install --no-dev
 
 RUN mkdir -p static/uploads
+
+RUN pre-commit run --all-files
 
 EXPOSE 5000
 #ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,22 @@ ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 COPY app /app/.
 COPY pyproject.toml /app/pyproject.toml
 
-RUN pip3 install --no-cache-dir --upgrade pip && \
+# static dependencies
+RUN apt-get update &&\
+    apt install -y git &&\
+    pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir poetry && \
     pip3 install --no-cache-dir pre-commit && \
-    poetry config virtualenvs.create false && \
-    poetry install --no-dev
+    poetry config virtualenvs.create false
+
+RUN poetry install --no-dev
 
 RUN mkdir -p static/uploads
 
-RUN pre-commit run --all-files
+RUN git init &&\
+    pre-commit run --all-files
 
 EXPOSE 5000
+
 #ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]
 ENTRYPOINT ["python3", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
 RUN mkdir -p static/uploads
 
 EXPOSE 5000
-#CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]
-#CMD ["python3", "main.py"]
+#ENTRYPOINT ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]
+ENTRYPOINT ["python3", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM python:3.10.6-slim-bullseye
 WORKDIR /app
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 
-COPY app /app/.
-COPY pyproject.toml /app/pyproject.toml
-
-# static dependencies
+# install static dependencies
 RUN apt-get update &&\
     apt install -y git &&\
     pip3 install --no-cache-dir --upgrade pip && \
@@ -14,11 +11,19 @@ RUN apt-get update &&\
     pip3 install --no-cache-dir pre-commit && \
     poetry config virtualenvs.create false
 
+# add dependency file
+COPY pyproject.toml /app/pyproject.toml
+
+# install project dependencies
 RUN poetry install --no-dev
 
+# add other project files
+COPY app /app/.
 RUN mkdir -p static/uploads
 
+# test & lint
 RUN git init &&\
+    git checkout -b ci &&\
     pre-commit run --all-files
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 
 COPY app /app/.
 COPY pyproject.toml /app/pyproject.toml
-COPY .env ./
 
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir poetry && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN poetry install --no-dev
 
 # add other project files
 COPY app /app/.
+COPY .pre-commit-config.yaml .flake8 /app/
 RUN mkdir -p static/uploads
 
 # test & lint

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ This is the backend of the Age of GOLD project. Here we will store the hexagonal
 
 ## Run in dev
 
-Start a ephemeral database (keep running):
-
-    docker run --name postgres-dev -ePOSTGRES_DB=aog -ePOSTGRES_PASSWORD=S3cr37 -d postgres
+Some services need to be running and configured; you can start them with docker-compose.
 
 Build the AoG image:
 
@@ -14,4 +12,5 @@ Build the AoG image:
 
 Run the image you just built:
 
-    docker run -ePOSTGRES_URL=localhost -ePOSTGRES_PORT=5000 -ePOSTGRES_DB=aog -ePOSTGRES_USER=postgres -ePOSTGRES_PASSWORD=S3cr37 -it aog
+    docker run -it aog
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Age of GOLD
 
 This is the backend of the Age of GOLD project. Here we will store the hexagonal map information.
+
+## Run in dev
+
+Start a ephemeral database (keep running):
+
+    docker run --name postgres-dev -ePOSTGRES_DB=aog -ePOSTGRES_PASSWORD=S3cr37 -d postgres
+
+Build the AoG image:
+
+    docker build -t aog .
+
+Run the image you just built:
+
+    docker run -ePOSTGRES_URL=localhost -ePOSTGRES_PORT=5000 -ePOSTGRES_DB=aog -ePOSTGRES_USER=postgres -ePOSTGRES_PASSWORD=S3cr37 -it aog


### PR DESCRIPTION
This will run tests and lints (from pre-commit) for commits to `main`, for PRs, and when clicking the button in the Actions tab. It pushes the Docker image to Dockerhub for `main` but not for unmerged PRs.

Proof of concept here: https://hub.docker.com/r/mverleg/age_of_gold/tags

Two manual changes are needed:

* Access token: Get a Dockerhub access token from Dockerhub, and create a secret in the settings of this repository called `DOCKERHUB_ACCESS_TOKEN` and containing the key from Dockerhub.
* In the last line of `.github/workflows/pub_img.yml` update the repository url (3 times)